### PR TITLE
Add support references.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,3 +34,11 @@ corresponding to your locale.  For the other characters, use the
 
 The strings must not contain HTML or JavaScript.  They are sorted by key for
 easy diffing.
+
+Error Messages
+--------------
+
+By its very nature, this repository contains almost all the error messages that
+cPanel & WHM produces.  If you came here because you're looking for support,
+please see https://cpanel.com/support/[our support page] for information on how
+to open a ticket and access our forums.


### PR DESCRIPTION
Because the repository contains many error messages, it's a prime target
for Google to direct people to.  Provide a link to support resources for
those who need them.